### PR TITLE
Port simulation to SimPy v4

### DIFF
--- a/examples/gantt.py
+++ b/examples/gantt.py
@@ -62,7 +62,7 @@ def gantt_test():
             print("%s: wcrt=%d" % (t.name, results[t].wcrt))
 
     simmodel = simulation.ResourceModel(r1)
-    simmodel.runModel(task=t12, scheduler=simulation.SimSPP(name="SPP", sim=simmodel))
+    simmodel.runModel(task=t12, scheduler=simulation.SimSPP(name="SPP", env=simmodel))
 
 
     # plot

--- a/examples/gantt.py
+++ b/examples/gantt.py
@@ -62,7 +62,7 @@ def gantt_test():
             print("%s: wcrt=%d" % (t.name, results[t].wcrt))
 
     simmodel = simulation.ResourceModel(r1)
-    simmodel.runModel(task=t12, scheduler=simulation.SimSPP(name="SPP", env=simmodel))
+    simmodel.runModel(task=t12, scheduler=simulation.SimSPP(name="SPP", env=simmodel.env))
 
 
     # plot

--- a/pycpa/simulation.py
+++ b/pycpa/simulation.py
@@ -158,12 +158,7 @@ class SimSPP:
         if len(self.pending) == 0:
             return None
 
-        s = self.pending[-1]
-
-        # we look
-        for a in reversed(self.pending):
-            if a.task.scheduling_parameter <= s.task.scheduling_parameter:
-                s = a
+        s = min(self.pending, key=lambda a: a.task.scheduling_parameter)
         return s
 
     def idle(self):
@@ -242,10 +237,7 @@ class SimSPNP:
         if len(self.pending) == 0:
             return None
 
-        s = self.pending[-1]
-        for a in reversed(self.pending):
-            if a.task.scheduling_parameter <= s.task.scheduling_parameter:
-                s = a
+        s = min(self.pending, key=lambda a: a.task.scheduling_parameter)
         return s
 
     def idle(self):

--- a/pycpa/simulation.py
+++ b/pycpa/simulation.py
@@ -311,6 +311,7 @@ class ResourceModel:
             simtask = SimTask(self.env, t)
             self.scheduler.simtasks.append(simtask)
 
-        self.env.scheduler_proc = self.env.process(self.scheduler.execute(self.resource, task))
+        self.env.process(self.scheduler.execute(self.resource, task))
         self.env.run(until=until)
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Thanks a lot for this open-sourced powerful tool!

I found `pycpa/simulation.py` requires SimPy v2, which is not specified in `setup.py`.
The latest SimPy seems more concise and readable to me, so I've ported the code to SimPy v4.

It's done in commit b280b2f, following [the official guide for porting](https://simpy.readthedocs.io/en/latest/topical_guides/porting_from_simpy2.html).
And other commits are merely for tidying up.

I have confirmed `examples/gantt.py` generating the same chart after porting, with `r1` scheduler be SPP or SPNP.